### PR TITLE
feat: Implement city dropdown in address form and enhance module conf…

### DIFF
--- a/pslocationlocator/views/assets/js/gps_address.js
+++ b/pslocationlocator/views/assets/js/gps_address.js
@@ -5,19 +5,35 @@
  */
 
 $(document).ready(function() {
-    // Check if the specific button for GPS exists. This button should only be added to the DOM for Iran.
-    // The related hidden fields gps_latitude and gps_longitude are also assumed to be present.
-    const getGpsButton = $('#get-gps-location-btn'); // Assuming this ID for the button
-    const latitudeInput = $('#gps_latitude');       // Assuming this ID for the hidden latitude input
-    const longitudeInput = $('#gps_longitude');     // Assuming this ID for the hidden longitude input
-    const gpsStatusDiv = $('#gps-status-message');  // Assuming a div for status messages
+    // Logic to hide original city input if our dropdown is present
+    const cityDropdown = $('#psll_city_dropdown');
+    if (cityDropdown.length > 0) {
+        // Find the original city input field.
+        // We target specifically an input element with id="city" and name="city"
+        // to avoid conflicting with our select dropdown which also has name="city".
+        const originalCityInput = $('input#city[name="city"]');
+
+        if (originalCityInput.length > 0) {
+            // Hide its parent form-group.
+            originalCityInput.closest('.form-group').hide();
+        }
+    }
+
+    // Existing GPS button logic (should remain untouched by the above)
+    // Note: The IDs in the provided existing JS were generic.
+    // Using the specific IDs from the .tpl file for consistency:
+    // psll_get_location_btn, psll_gps_latitude, psll_gps_longitude, psll_gps_status
+    const getGpsButton = $('#psll_get_location_btn'); // Corrected ID from .tpl
+    const latitudeInput = $('#psll_gps_latitude');    // Corrected ID from .tpl
+    const longitudeInput = $('#psll_gps_longitude'); // Corrected ID from .tpl
+    const gpsStatusDiv = $('#psll_gps_status');       // Corrected ID from .tpl
 
     if (getGpsButton.length && latitudeInput.length && longitudeInput.length) {
         getGpsButton.on('click', function(e) {
-            e.preventDefault(); // Prevent form submission if it's a submit button or inside a form
+            e.preventDefault();
 
             if (gpsStatusDiv.length) {
-                gpsStatusDiv.text('در حال دریافت موقعیت مکانی شما...').removeClass('error success').addClass('info'); // Fetching location...
+                gpsStatusDiv.text('در حال دریافت موقعیت مکانی شما...').removeClass('error success').addClass('info').show();
             }
 
             if (navigator.geolocation) {
@@ -26,109 +42,48 @@ $(document).ready(function() {
                         const lat = position.coords.latitude;
                         const lon = position.coords.longitude;
 
-                        latitudeInput.val(lat.toFixed(8));   // Using .toFixed(8) as per DECIMAL(10,8)
-                        longitudeInput.val(lon.toFixed(8)); // Using .toFixed(8) as per DECIMAL(11,8)
+                        latitudeInput.val(lat.toFixed(8));
+                        longitudeInput.val(lon.toFixed(8));
 
                         if (gpsStatusDiv.length) {
-                            gpsStatusDiv.text('موقعیت مکانی با موفقیت دریافت شد.').removeClass('info error').addClass('success'); // Location captured successfully.
+                            gpsStatusDiv.text('موقعیت مکانی با موفقیت دریافت شد.').removeClass('info error').addClass('success');
                         }
-                        // Optionally, disable the button after successful capture or change its text
-                        // getGpsButton.prop('disabled', true).text('موقعیت دریافت شد');
                     },
                     function(error) {
-                        let errorMessage = 'خطا در دریافت موقعیت مکانی: '; // Error fetching location:
+                        let errorMessage = 'خطا در دریافت موقعیت مکانی: ';
                         switch (error.code) {
                             case error.PERMISSION_DENIED:
-                                errorMessage += 'دسترسی به موقعیت مکانی رد شد.'; // User denied the request for Geolocation.
+                                errorMessage += 'دسترسی به موقعیت مکانی رد شد.';
                                 break;
                             case error.POSITION_UNAVAILABLE:
-                                errorMessage += 'اطلاعات موقعیت مکانی در دسترس نیست.'; // Location information is unavailable.
+                                errorMessage += 'اطلاعات موقعیت مکانی در دسترس نیست.';
                                 break;
                             case error.TIMEOUT:
-                                errorMessage += 'زمان درخواست برای دریافت موقعیت مکانی به پایان رسید.'; // The request to get user location timed out.
+                                errorMessage += 'زمان درخواست برای دریافت موقعیت مکانی به پایان رسید.';
                                 break;
                             case error.UNKNOWN_ERROR:
-                                errorMessage += 'یک خطای ناشناخته رخ داد.'; // An unknown error occurred.
+                                errorMessage += 'یک خطای ناشناخته رخ داد.';
                                 break;
                         }
                         if (gpsStatusDiv.length) {
                             gpsStatusDiv.text(errorMessage).removeClass('info success').addClass('error');
                         }
-                        // Clear hidden fields on error to avoid submitting stale/failed data
+                        // Clear inputs on error
                         latitudeInput.val('');
                         longitudeInput.val('');
                     },
                     {
-                        enableHighAccuracy: true,
-                        timeout: 10000, // 10 seconds
-                        maximumAge: 0 // Don't use a cached position
+                        enableHighAccuracy: true, // Attempt to get a more precise location
+                        timeout: 10000,          // Maximum time (in milliseconds) to wait for a response
+                        maximumAge: 0            // Force a fresh location query
                     }
                 );
             } else {
                 if (gpsStatusDiv.length) {
-                    gpsStatusDiv.text('مرورگر شما از موقعیت یابی جغرافیایی پشتیبانی نمی کند.').removeClass('info success').addClass('error'); // Geolocation is not supported by this browser.
+                    gpsStatusDiv.text('مرورگر شما از موقعیت یابی جغرافیایی پشتیبانی نمی کند.').removeClass('info success').addClass('error');
                 }
             }
         });
-    } else {
-        // Optional: log if elements are not found, for debugging module setup
-        // console.log('PSLocationLocator: GPS button or input fields not found on this page.');
     }
-
-    // Logic to show/hide the button based on country selection (Iran - ISO 'IR')
-    // This is best handled when the form is built (PHP/Smarty), but a JS fallback can be added.
-    // We need to know the ID of the country selector dropdown.
-    // Assuming PrestaShop's default address form country selector has id 'id_country'.
-    const countrySelector = $('#id_country'); // Common ID for country selector in PrestaShop forms
-
-    function toggleGpsFeature() {
-        // This assumes the button and its container are managed for visibility.
-        // Let's assume the button (and hidden fields, status message area) are wrapped in a container.
-        // e.g., <div id="psll-gps-feature-container"> ... button, inputs, status ... </div>
-        const gpsFeatureContainer = $('#psll-gps-feature-container'); // Wrapper for all GPS elements
-
-        if (countrySelector.length && gpsFeatureContainer.length) {
-            if (countrySelector.val() == getIdCountryByIso('IR')) { // getIdCountryByIso('IR') needs to be a JS var from PHP
-                gpsFeatureContainer.show();
-            } else {
-                gpsFeatureContainer.hide();
-                // Clear fields if country changes away from IR after getting location
-                latitudeInput.val('');
-                longitudeInput.val('');
-                if (gpsStatusDiv.length) {
-                    gpsStatusDiv.text('');
-                }
-            }
-        }
-    }
-
-    if (countrySelector.length) {
-        // Call it once on page load
-        // We need `id_country_iran` to be passed from PHP to JS, e.g. via `Media::addJsDef`
-        // For now, let's assume `prestashop.variables.id_country_iran` is available.
-        // This part of the JS is more complex as it relies on PHP passing data.
-        // The primary requirement is that the button is added for IR.
-        // The JS should work if the button IS present.
-
-        // Simpler approach: The PHP hook should ONLY add the button/container if country is IR.
-        // If not, gpsFeatureContainer won't exist, and the JS won't do anything.
-        // If the form allows changing country and it reloads parts via AJAX, this could get complex.
-        // Standard PrestaShop address form reloads on country change.
-        // So, if the button is added by PHP based on initial country, this JS is fine.
-        // If country changes, page reloads, PHP hook re-evaluates.
-
-        // The initial check `if (getGpsButton.length ...)` is key.
-        // The button should only be printed by the hook if country is Iran.
-    }
+    // Any other existing JS logic can follow here
 });
-
-// Helper function (if needed, or this logic is in PHP)
-// function getIdCountryByIso(isoCode) {
-// This would require `countries` variable passed from PHP, containing {iso_code: id_country} map.
-// For 'IR', this is typically a fixed ID in a PrestaShop installation, but can vary.
-// It's better if the specific ID for Iran is passed from PHP if this dynamic show/hide in JS is used.
-// Example: if (prestashop && prestashop.variables && prestashop.variables.id_country_iran) {
-// return prestashop.variables.id_country_iran;
-// }
-// return 0; // Default or error
-// }

--- a/views/templates/hook/displayAddressFormFields.tpl
+++ b/views/templates/hook/displayAddressFormFields.tpl
@@ -25,6 +25,8 @@
                     </option>
                 {/foreach}
             </select>
+            {* The original city text input will be hidden by JavaScript (Step 4) *}
+            {* We are providing a new select element with name="city" *}
         </div>
     </div>
 {/if}
@@ -33,20 +35,14 @@
     <div class="form-group row">
         <label class="col-md-3 form-control-label">{l s='GPS Location' mod='pslocationlocator'}</label>
         <div class="col-md-7">
-            {* Corrected ID here to match original intent and previous JS if it was targeting this directly.
-               However, JS was last updated to use #psll_get_location_btn.
-               For consistency with the *last* JS update, this should be id="psll_get_location_btn".
-               If the JS is simpler to change back, this could be "get-gps-location-btn".
-               Given the review point, the JS has #psll_get_location_btn, so TPL should match.
-            *}
             <button type="button" id="psll_get_location_btn" class="btn btn-primary">{l s='Get My Current Location' mod='pslocationlocator'}</button>
-            <small id="psll_gps_status" class="form-text text-muted"></small> {# JS uses #psll_gps_status #}
+            <small id="psll_gps_status" class="form-text text-muted"></small>
         </div>
     </div>
 
     {* Hidden fields to store GPS coordinates. These will be populated by JavaScript. *}
-    <input type="hidden" name="gps_latitude" id="psll_gps_latitude" value="{$psll_existing_latitude|escape:'htmlall':'UTF-8'}"> {# JS uses #psll_gps_latitude #}
-    <input type="hidden" name="gps_longitude" id="psll_gps_longitude" value="{$psll_existing_longitude|escape:'htmlall':'UTF-8'}"> {# JS uses #psll_gps_longitude #}
+    <input type="hidden" name="gps_latitude" id="psll_gps_latitude" value="{$psll_existing_latitude|escape:'htmlall':'UTF-8'}">
+    <input type="hidden" name="gps_longitude" id="psll_gps_longitude" value="{$psll_existing_longitude|escape:'htmlall':'UTF-8'}">
 
     {* Optional: Display current coordinates if they exist for debugging or info *}
     {if $psll_existing_latitude && $psll_existing_longitude}


### PR DESCRIPTION
…iguration

This commit introduces a city selection dropdown in the address form and significantly enhances the module's configuration capabilities.

Key changes:

1.  **City Dropdown Functionality:**
    *   The address form now displays a dropdown list of cities if the selected country is configured as active for this feature.
    *   This dropdown replaces the standard city text input field.
    *   The list of cities is populated from a new 'Allowed Cities' setting in the module's configuration page.

2.  **Enhanced Module Configuration:**
    *   Added a multi-select field in the module settings to allow administrators to choose countries for which the city dropdown will be active. This list is populated from active countries in PrestaShop's localization.
    *   The 'Allowed Cities' configuration (textarea for comma-separated city names) is used to populate the new city dropdown.
    *   Defaulted the 'Enabled Country for City Dropdown' to Iran on installation.

3.  **GPS Functionality Adjustments:**
    *   The existing GPS location capture feature (button on address form, saving coordinates, display on order/admin/invoice, QR code) is preserved.
    *   Element IDs for GPS components in the address form template (`displayAddressFormFields.tpl`) have been updated (e.g., `psll_get_location_btn`, `psll_gps_latitude`) to align with JavaScript selectors, ensuring correct operation. The GPS button visibility remains tied to the country being Iran.

4.  **Code Structure and Fixes:**
    *   Updated `hookDisplayAddressForm` to manage visibility and data for both the city dropdown and the GPS button.
    *   Modified `displayAddressFormFields.tpl` to correctly render these conditional sections.
    *   Adjusted `gps_address.js` to hide the original city text input when the dropdown is active and to use consistent selectors for GPS elements.
    *   Reviewed and confirmed `hookActionCarrierProcess` correctly validates against the city selected from the dropdown.

These changes provide a more user-friendly way for your customers in specific regions to enter their city while maintaining the module's GPS location features and admin-configurable shipping restrictions based on city.